### PR TITLE
fix consistency level spelling ( week -> weak )

### DIFF
--- a/app/controllers/RequestParser.scala
+++ b/app/controllers/RequestParser.scala
@@ -298,7 +298,7 @@ trait RequestParser extends JSONParser {
     jsObjDuplicateKeyCheck(metaJs)
     val idxProps = for ((k, v) <- idxJs.fields) yield (k, v)
     val metaProps = for ((k, v) <- metaJs.fields) yield (k, v)
-    val consistencyLevel = (jsValue \ "consistencyLevel").asOpt[String].getOrElse("week")
+    val consistencyLevel = (jsValue \ "consistencyLevel").asOpt[String].getOrElse("weak")
     // expect new label don`t provide hTableName
     val hTableName = (jsValue \ "hTableName").asOpt[String]
     val hTableTTL = (jsValue \ "hTableTTL").asOpt[Int]

--- a/migrate/mysql/schema.sql
+++ b/migrate/mysql/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE `labels` (
   `is_directed` tinyint	NOT NULL DEFAULT 1,
   `service_name` varchar(64),
   `service_id` integer NOT NULL,
-  `consistency_level` varchar(8) NOT NULL DEFAULT 'week',
+  `consistency_level` varchar(8) NOT NULL DEFAULT 'weak',
   `hbase_table_name` varchar(255) NOT NULL DEFAULT 's2graph',
   `hbase_table_ttl` integer,
   `is_async` tinyint	NOT NULL DEFAULT 0,

--- a/s2core/migrate/mysql/schema.sql
+++ b/s2core/migrate/mysql/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE `labels` (
   `is_directed` tinyint	NOT NULL DEFAULT 1,
   `service_name` varchar(64),
   `service_id` integer NOT NULL,
-  `consistency_level` varchar(8) NOT NULL DEFAULT 'week',
+  `consistency_level` varchar(8) NOT NULL DEFAULT 'weak',
   `hbase_table_name` varchar(255) NOT NULL DEFAULT 's2graph',
   `hbase_table_ttl` integer,
   PRIMARY KEY (`id`),

--- a/s2core/src/main/scala/com/daumkakao/s2graph/core/GraphUtil.scala
+++ b/s2core/src/main/scala/com/daumkakao/s2graph/core/GraphUtil.scala
@@ -14,7 +14,7 @@ object GraphUtil {
         (k -> v.toByte)
     }
   val directions = Map("out" -> 0, "in" -> 1, "undirected" -> 2, "u" -> 2, "directed" -> 0, "d" -> 0)
-  val consistencyLevel = Map("week" -> 0, "strong" -> 1)
+  val consistencyLevel = Map("weak" -> 0, "strong" -> 1)
   
   def toType(t: String) = {
     t.trim().toLowerCase() match {


### PR DESCRIPTION
I think consistency level name from `week` to `weak` is better.
