### PR TITLE
Add slide / presentation links to HBaseConf 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -2206,7 +2206,10 @@ total vuser = 2,072
 
 
 ## 8. Resources ##
-* [hbaseconf](http://hbasecon.com/agenda): presentation is not published yet, but you can find our [keynote](https://www.dropbox.com/home?preview=hbasecon_s2graph_final.key)
+* [hbaseconf](http://hbasecon.com/agenda)
+  * HBaseCon2015: S2Graph - A Large-scale Graph Database with HBase
+     * [presentation](https://vimeo.com/128203919)
+     * [slide](http://www.slideshare.net/HBaseCon/use-cases-session-5)
 * mailing list: use [google group](https://groups.google.com/forum/#!forum/s2graph) or fire issues on this repo.
 * contact: shom83@gmail.com
 


### PR DESCRIPTION
For now Cloudera shares HBaseConf 2015 presentation to Vimeo, and HBaseCon shares slides to SlideShare.
We may want to replace Dropbox link to these since it is easier to see, share, like, save, take any social actions, which promotes S2Graph more aggressively.

I've already submit CLA for Individual. Please let me know if I need to submit any other forms.

Thanks in advance. 
