### PR TITLE
change outPath, compatible with Hive ext. table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ lazy val commonSettings = Seq(
     "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
     "Cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos",
     "Twitter Maven" at "http://maven.twttr.com",
-    "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+    "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+    "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
   )
 )
 

--- a/loader/src/main/scala/subscriber/WalLogToHDFS.scala
+++ b/loader/src/main/scala/subscriber/WalLogToHDFS.scala
@@ -14,8 +14,8 @@ import scala.language.postfixOps
 
 object WalLogToHDFS extends SparkApp with WithKafka {
   private def toOutputPath(ts: Long): String = {
-    val formatter = new SimpleDateFormat("yyyy/MM/dd")
-    Seq(formatter.format(new Date(ts)), ts.toString).mkString("/")
+    val dateId = new SimpleDateFormat("yyyy-MM-dd").format(new Date(ts))
+    s"date_id=$dateId/ts=$ts"
   }
 
   val usages =


### PR DESCRIPTION
add the resolver for scalaz

and change outputPath as date_id=$date_id/ts=$ts

for create external table as

```
CREATE EXTERNAL TABLE wal(
  log_ts bigint,
  o string,
  lt string,
  f string, -- from or id
  t string, -- to or service
  l string, -- label or column
  p string, -- props, if service is null, this values is the service and the props is null
  s string  -- service, can be null, then the props is the service
)
PARTITIONED BY (
  date_id string,
  ts string
)
ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
LOCATION "/path/to/wal";
```

then add partitions as

```
ALTER TABLE wal ADD PARTITION(date_id='2015-09-08', ts='1441699800000');
```
