### PR TITLE
s2core/migrate/mysql/schema.sql modified

### DIFF
--- a/s2core/migrate/mysql/schema.sql
+++ b/s2core/migrate/mysql/schema.sql
@@ -141,6 +141,7 @@ DROP TABLE IF EXISTS `experiments`;
 CREATE TABLE `experiments` (
   `id` integer NOT NULL AUTO_INCREMENT,
   `service_id` integer NOT NULL,
+  `service_name` varchar(128) NOT NULL,
   `name` varchar(64) NOT NULL,
   `description` varchar(255) NOT NULL,
   `experiment_type` varchar(8) NOT NULL DEFAULT 'u',
@@ -163,6 +164,8 @@ CREATE TABLE `buckets` (
   `traffic_ratios` varchar(64) NOT NULL,
   `http_verb` varchar(8) NOT NULL,
   `api_path` text NOT NULL,
+  `uuid_key` varchar(128),
+  `uuid_placeholder` varchar(64),
   `request_body` text NOT NULL,
   `timeout` int NOT NULL DEFAULT 1000,
   `impression_id` varchar(64) NOT NULL,


### PR DESCRIPTION
buckets tables's uuid_key, uuid_placeholder are omitted.
experiments tables's service_name is omitted.
