### PR TITLE
change parsing inteval prop

### DIFF
--- a/app/controllers/RequestParser.scala
+++ b/app/controllers/RequestParser.scala
@@ -40,11 +40,18 @@ trait RequestParser extends JSONParser {
   def extractInterval(label: Label, jsValue: JsValue) = {
     val ret = for {
       js <- parse[Option[JsObject]](jsValue, "interval")
-      fromJs <- parse[Option[JsObject]](js, "from")
-      toJs <- parse[Option[JsObject]](js, "to")
+      fromJs <- (js \ "from").asOpt[JsValue]
+      toJs <- (js \ "to").asOpt[JsValue]
     } yield {
-        val from = Management.toProps(label, fromJs)
-        val to = Management.toProps(label, toJs)
+        val from = fromJs match {
+          case JsObject(obj) => Management.toProps(label, obj)
+          case JsArray(arr) => Management.toProps(label, arr.flatMap { case JsObject(obj) => obj })
+        }
+        val to = toJs match {
+          case JsObject(obj) => Management.toProps(label, obj)
+          case JsArray(arr) => Management.toProps(label, arr.flatMap { case JsObject(obj) => obj })
+        }
+
         (from, to)
       }
     ret

--- a/s2core/src/main/scala/com/daumkakao/s2graph/core/Management.scala
+++ b/s2core/src/main/scala/com/daumkakao/s2graph/core/Management.scala
@@ -265,7 +265,7 @@ object Management extends JSONParser {
     val op = tryOption(operation, GraphUtil.toOp)
 
     val jsObject = Json.parse(props).asOpt[JsObject].getOrElse(Json.obj())
-    val parsedProps = toProps(label, jsObject).toMap
+    val parsedProps = toProps(label, jsObject.fields).toMap
     val propsWithTs = parsedProps.map(kv => (kv._1 -> InnerValLikeWithTs(kv._2, ts))) ++
       Map(LabelMeta.timeStampSeq -> InnerValLikeWithTs(InnerVal.withLong(ts, label.schemaVersion), ts))
 
@@ -304,20 +304,14 @@ object Management extends JSONParser {
 
   }
 
-  def toProps(label: Label, js: JsObject): Seq[(Byte, InnerValLike)] = {
-
+  def toProps(label: Label, js: Seq[(String, JsValue)]): Seq[(Byte, InnerValLike)] = {
     val props = for {
-      (k, v) <- js.fields
+      (k, v) <- js
       meta <- label.metaPropsInvMap.get(k)
-      //        meta <- LabelMeta.findByName(label.id.get, k)
-      //      meta = tryOption((label.id.get, k), LabelMeta.findByName)
       innerVal <- jsValueToInnerVal(v, meta.dataType, label.schemaVersion)
-    } yield {
-        (meta.seq, innerVal)
-      }
-    //    logger.error(s"toProps: $js => $props")
-    props
+    } yield (meta.seq, innerVal)
 
+    props
   }
 
   val idTableName = "id"

--- a/s2core/src/test/scala/com/daumkakao/s2graph/core/parsers/WhereParserTest.scala
+++ b/s2core/src/test/scala/com/daumkakao/s2graph/core/parsers/WhereParserTest.scala
@@ -51,7 +51,7 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
     } {
       /** test for each version */
       val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
-      val propsInner = Management.toProps(label, js).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap
       val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, 0, propsInner)
       val f = validate(labelName)(edge) _
 
@@ -70,7 +70,7 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
     } {
       /** test for each version */
       val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
-      val propsInner = Management.toProps(label, js).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap
       val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, 0, propsInner)
 
       val f = validate(labelName)(edge) _
@@ -99,7 +99,7 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
     } {
       /** test for each version */
       val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
-      val propsInner = Management.toProps(label, js).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap
       val labelWithDirection = if (schemaVer == VERSION2) labelWithDirV2 else labelWithDir
       val edge = Edge(srcVertex, tgtVertex, labelWithDirection, 0.toByte, ts, 0, propsInner)
       val lname = if (schemaVer == VERSION2) labelNameV2 else labelName


### PR DESCRIPTION
Fix the bug: Inavalid order on parse "Interval" property

When parsing property `from` and `to`, key's ordering is broken, Json dosn't ensure JsObject's key ordering, but it must ordered

before: 

```
               "interval":{
                  "from": {
                    "_to":"",
                    "time_unit":"d",
                    "time_value":0
                  },
                  "to":{
                    "_to":"",
                    "time_unit":"d",
                    "time_value":1441876807011
                  }
               }
```

fixed:

```
               "interval":{
                  "from":[
                    {"_to":""},
                    {"time_unit":"d"},
                    {"time_value":0}
                  ],
                  "to":[
                    {"_to":""},
                    {"time_unit":"d"},
                    {"time_value":1441876807011}
                  ]
               }
```
