### PR TITLE
fix the bug: can't get edge with 0 vertex Id(same as degree edge)

### DIFF
--- a/s2core/src/main/scala/com/daumkakao/s2graph/core/Graph.scala
+++ b/s2core/src/main/scala/com/daumkakao/s2graph/core/Graph.scala
@@ -459,14 +459,16 @@ object Graph {
   }
 
 
-  type HashKey = (Int, Int, Int, Int)
+  type HashKey = (Int, Int, Int, Int, Boolean)
   type FilterHashKey = (Int, Int)
 
   def toHashKey(queryParam: QueryParam, edge: Edge): (HashKey, FilterHashKey) = {
+    val isDegree = edge.propsWithTs.containsKey(LabelMeta.degreeSeq)
     val src = edge.srcVertex.innerId.hashKey(queryParam.srcColumnWithDir.columnType)
     val tgt = edge.tgtVertex.innerId.hashKey(queryParam.tgtColumnWithDir.columnType)
-    val hashKey = (src, edge.labelWithDir.labelId, edge.labelWithDir.dir, tgt)
+    val hashKey = (src, edge.labelWithDir.labelId, edge.labelWithDir.dir, tgt, isDegree)
     val filterHashKey = (src, tgt)
+
     (hashKey, filterHashKey)
   }
 

--- a/test/controllers/QuerySpec.scala
+++ b/test/controllers/QuerySpec.scala
@@ -44,7 +44,7 @@ class QuerySpec extends SpecCommon with PlaySpecification {
       Thread.sleep(asyncFlushInterval)
     }
 
-    def query(id: Int) = Json.parse( s"""
+    def queryExclude(id: Int) = Json.parse( s"""
         { "srcVertices": [
           { "serviceName": "${testServiceName}",
             "columnName": "${testColumnName}",
@@ -151,8 +151,6 @@ class QuerySpec extends SpecCommon with PlaySpecification {
       $(srcVertices = $from, steps = $steps).toJson
     }
 
-
-
     "get edge with where condition" in {
       running(FakeApplication()) {
         var result = getEdges(queryWhere(0, "is_hidden=false and _from in (-1, 0)"))
@@ -174,7 +172,7 @@ class QuerySpec extends SpecCommon with PlaySpecification {
 
     "get edge exclude" in {
       running(FakeApplication()) {
-        val result = getEdges(query(0))
+        val result = getEdges(queryExclude(0))
         (result \ "results").as[List[JsValue]].size must equalTo(1)
       }
     }
@@ -187,9 +185,9 @@ class QuerySpec extends SpecCommon with PlaySpecification {
         result = getEdges(queryTransform(0, "[[\"weight\"]]"))
         (result \\ "to").map(_.toString).sorted must equalTo((result \\ "weight").map(_.toString).sorted)
 
-        // FIXME: brokwn
         result = getEdges(queryTransform(0, "[[\"_from\"]]"))
-        (result \\ "to").map(_.toString).sorted must equalTo((result \\ "from").map(_.toString).sorted)
+        val results = (result \ "results").as[JsValue]
+        (result \\ "to").map(_.toString).sorted must equalTo((results \\ "from").map(_.toString).sorted)
       }
     }
 


### PR DESCRIPTION
Add hash key prop(isDegreeEdge)

When getting edge that has '0' vertexId it's same as degree Edge's vertexId, because it filted out, but it's not correct action.
