### PR TITLE
fixed typos and some static values are refactored

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/QueryResult.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/QueryResult.scala
@@ -9,7 +9,7 @@ object QueryResult {
     for {
       vertex <- vertices
       queryParam <- queryParams
-    } yield QueryResult(query, stepIdx, queryParam, Seq((Edge(vertex, vertex, queryParam.labelWithDir), Graph.defaultScore)))
+    } yield QueryResult(query, stepIdx, queryParam, Seq((Edge(vertex, vertex, queryParam.labelWithDir), Graph.DEFAULT_SCORE)))
   }
 }
 


### PR DESCRIPTION
The method name is mispelled.
defferedToFuture -> deferredToFuture

Some default static values that are written repetitively are refactored.
