### PR TITLE
fixed score calculation error when use multi label query at first step

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/QueryResult.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/QueryResult.scala
@@ -8,7 +8,7 @@ object QueryResult {
   def fromVertices(query: Query, stepIdx: Int, queryParams: Seq[QueryParam], vertices: Seq[Vertex]): Seq[QueryResult] = {
     for {
       vertex <- vertices
-      queryParam <- queryParams
+      queryParam = queryParams.head
     } yield QueryResult(query, stepIdx, queryParam, Seq((Edge(vertex, vertex, queryParam.labelWithDir), Graph.defaultScore)))
   }
 }


### PR DESCRIPTION
The score is multiplied by the number of labels when use multiple-label at first step. 
At the below example query, each edge has own score value (5) but the result score is doubled(10).

```
// query
{
  "srcVertices": [{"serviceName": "s2graph", "columnName": "user_id", "id": 1}],
  "steps": [
    {
      "step": [
        {"label": "label_test1", "limit": 1, "scoring": {"score": 1}},
        {"label": "label_test2", "limit": 1, "scoring": {"score": 1}}
      ]
    }
  ]
}
// results
{
    "size": 2,
   "results": [
        {
            "cacheRemain": -252,
            "timestamp": 1444124876,
            "score": 10,
            "label": "label_test2",
            "direction": "out",
            "to": "F",
            "_timestamp": 1444124876,
            "from": 1,
            "props": {
                "timestamp": 1444124876,
                "count": -1,
                "score": 5
            }
        },
        {
            "cacheRemain": -276,
            "timestamp": 1444124871,
            "score": 10,
            "label": "label_test1",
            "direction": "out",
            "to": "A",
            "_timestamp": 1444124871,
            "from": 1,
            "props": {
                "timestamp": 1444124871,
                "count": -1,
                "score": 5
            }
        }
    ],
    "impressionId": -2064807205
}
```
