### PR TITLE
add global limit

### DIFF
--- a/app/controllers/RequestParser.scala
+++ b/app/controllers/RequestParser.scala
@@ -133,6 +133,7 @@ trait RequestParser extends JSONParser {
       val groupByColumns = (jsValue \ "groupBy").asOpt[List[String]].getOrElse(List.empty)
       val withScore = (jsValue \ "withScore").asOpt[Boolean].getOrElse(true)
       val returnTree = (jsValue \ "returnTree").asOpt[Boolean].getOrElse(false)
+      val limit = (jsValue \ "limit").asOpt[Int].getOrElse(Query.defaultLimit)
 
       // TODO: throw exception, when label dosn't exist
       val labelMap = (for {
@@ -195,7 +196,7 @@ trait RequestParser extends JSONParser {
 
       val ret = Query(vertices, querySteps, removeCycle = removeCycle,
         selectColumns = selectColumns, groupByColumns = groupByColumns, filterOutQuery = filterOutQuery, withScore = withScore,
-        returnTree = returnTree)
+        returnTree = returnTree, limit = limit)
       //      logger.debug(ret.toString)
       ret
     } catch {

--- a/s2core/src/main/scala/com/kakao/s2graph/core/QueryParam.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/QueryParam.scala
@@ -14,6 +14,7 @@ import scala.util.{Success, Try}
 
 object Query {
   val initialScore = 1.0
+  val defaultLimit = 1000
   lazy val empty = Query()
 
   def toQuery(srcVertices: Seq[Vertex], queryParam: QueryParam) = Query(srcVertices, Vector(Step(List(queryParam))))
@@ -41,7 +42,8 @@ case class Query(vertices: Seq[Vertex] = Seq.empty[Vertex],
                  groupByColumns: Seq[String] = Seq.empty[String],
                  filterOutQuery: Option[Query] = None,
                  withScore: Boolean = true,
-                 returnTree: Boolean = false) {
+                 returnTree: Boolean = false,
+                 limit: Int = Query.defaultLimit) {
 
   lazy val selectColumnsSet = selectColumns.map { c =>
     if (c == "_from") "from"


### PR DESCRIPTION
The limit term can be used to constrain the number of edges at final results. It will be useful at multi-step query especially

Please refer to below example, the number of edges will be 10 at most.

```
{
  "limit" : 10,
  "srcVertices": [{"serviceName": "s2graph", "columnName": "user_id", "id": 1}],
  "steps": [
    {
      "step": [ {"label": "user_click_item", "direction":"out", "limit": 10, "scoring": {"score": 1}} ]
    },
    {
      "step": [ {"label": "user_click_item", "direction":"in", "limit": 10, "scoring": {"score": 1}} ]
    },
    {
      "step": [ {"label": "user_click_item", "direction":"out", "limit": 10, "scoring": {"score": 1}} ]
    }
  ]
}
```
