### PR TITLE
support random sampling query results

### DIFF
--- a/app/controllers/RequestParser.scala
+++ b/app/controllers/RequestParser.scala
@@ -292,9 +292,11 @@ trait RequestParser extends JSONParser {
       val outputField = (labelGroup \ "outputField").asOpt[String].map(s => Json.arr(Json.arr(s)))
       val transformer = if (outputField.isDefined) outputField else (labelGroup \ "transform").asOpt[JsValue]
       val scorePropagateOp = (labelGroup \ "scorePropagateOp").asOpt[String].getOrElse("multiply")
+      val sample = (labelGroup \ "sample").asOpt[Int].getOrElse(-1)
 
       // FIXME: Order of command matter
       QueryParam(labelWithDir)
+        .sample(sample)
         .limit(offset, limit)
         .rank(RankParam(label.id.get, scoring))
         .exclude(exclude)

--- a/s2core/src/main/scala/com/kakao/s2graph/core/QueryParam.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/QueryParam.scala
@@ -231,6 +231,7 @@ case class QueryParam(labelWithDir: LabelWithDirection, timestamp: Long = System
 
   var labelOrderSeq = fullKey
 
+  var sample = -1
   var limit = 10
   var offset = 0
   var rank = new RankParam(labelWithDir.labelId, List(LabelMeta.countSeq -> 1))
@@ -289,6 +290,11 @@ case class QueryParam(labelWithDir: LabelWithDirection, timestamp: Long = System
 
   def labelOrderSeq(labelOrderSeq: Byte): QueryParam = {
     this.labelOrderSeq = labelOrderSeq
+    this
+  }
+
+  def sample(n: Int): QueryParam = {
+    this.sample = n
     this
   }
 

--- a/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseQueryBuilder.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseQueryBuilder.scala
@@ -95,7 +95,7 @@ class AsynchbaseQueryBuilder(storage: AsynchbaseStorage)(implicit ec: ExecutionC
 
     def sample(edges: Seq[EdgeWithScore], n: Int): Seq[EdgeWithScore] = {
       val pureEdges = (if (queryRequest.queryParam.offset == 0) {
-        edges.filterNot { case x => x.edge.propsPlusTs.contains(LabelMeta.degreeSeq) }
+        edges.tail
       } else edges).toArray
 
       val sampled = new Array[EdgeWithScore](n)

--- a/test/benchmark/SamplingBenchmarkSpec.scala
+++ b/test/benchmark/SamplingBenchmarkSpec.scala
@@ -24,12 +24,10 @@ class SamplingBenchmarkSpec extends BenchmarkCommon with PlaySpecification {
         val randomNum = randomInt(num, ls.size)
         var sample = List.empty[T]
         var idx = 0
-
         ls.foreach { e =>
           if (randomNum.contains(idx)) sample = e :: sample
           idx += 1
         }
-
         sample
       }
 
@@ -82,7 +80,7 @@ class SamplingBenchmarkSpec extends BenchmarkCommon with PlaySpecification {
 
       duration("RNG Sampling") {
         (0 to testLimit) foreach { _ =>
-          val sampled = randomArraySample(testNum, testData)
+          val sampled = rngSample(testNum, testData)
         }
       }
     }

--- a/test/controllers/QuerySpec.scala
+++ b/test/controllers/QuerySpec.scala
@@ -4,6 +4,8 @@ import play.api.libs.json._
 import play.api.test.{FakeApplication, FakeRequest, PlaySpecification}
 import play.api.{Application => PlayApplication}
 
+import scala.concurrent.Await
+
 class QuerySpec extends SpecCommon with PlaySpecification {
 
   import Helper._
@@ -39,7 +41,7 @@ class QuerySpec extends SpecCommon with PlaySpecification {
       val jsResult = contentAsJson(EdgeController.mutateAndPublish(bulkEdges, withWait = true))
     }
 
-    def queryParents(id: Long) = Json.parse(s"""
+    def queryParents(id: Long) = Json.parse( s"""
         {
           "returnTree": true,
           "srcVertices": [
@@ -153,6 +155,79 @@ class QuerySpec extends SpecCommon with PlaySpecification {
           ]]
         }
         """)
+
+    def queryWithSampling(id: Int, sample: Int) = Json.parse( s"""
+        { "srcVertices": [
+          { "serviceName": "${testServiceName}",
+            "columnName": "${testColumnName}",
+            "id": ${id}
+           }],
+          "steps": [
+            {
+              "step": [{
+                "label": "${testLabelName}",
+                "direction": "out",
+                "offset": 0,
+                "limit": 100,
+                "sample": ${sample}
+                }]
+            }
+          ]
+        }""")
+
+
+    def twoStepQueryWithSampling(id: Int, sample: Int) = Json.parse( s"""
+        { "srcVertices": [
+          { "serviceName": "${testServiceName}",
+            "columnName": "${testColumnName}",
+            "id": ${id}
+           }],
+          "steps": [
+            {
+              "step": [{
+                "label": "${testLabelName}",
+                "direction": "out",
+                "offset": 0,
+                "limit": 100,
+                "sample": ${sample}
+                }]
+            },
+            {
+               "step": [{
+                 "label": "${testLabelName}",
+                 "direction": "out",
+                 "offset": 0,
+                 "limit": 100,
+                 "sample": ${sample}
+               }]
+            }
+          ]
+        }""")
+
+    def twoQueryWithSampling(id: Int, sample: Int) = Json.parse( s"""
+        { "srcVertices": [
+          { "serviceName": "${testServiceName}",
+            "columnName": "${testColumnName}",
+            "id": ${id}
+           }],
+          "steps": [
+            {
+              "step": [{
+                "label": "${testLabelName}",
+                "direction": "out",
+                "offset": 0,
+                "limit": 50,
+                "sample": ${sample}
+              },
+              {
+                "label": "${testLabelName2}",
+                "direction": "out",
+                "offset": 0,
+                "limit": 50
+              }]
+            }
+          ]
+        }""")
 
     def queryUnion(id: Int, size: Int) = JsArray(List.tabulate(size)(_ => querySingle(id)))
 
@@ -307,7 +382,7 @@ class QuerySpec extends SpecCommon with PlaySpecification {
           (js \ "weight").as[Int]
         }
         weights must contain(exactly(30, 40))
-        weights must not contain(10)
+        weights must not contain (10)
       }
     }
 
@@ -339,7 +414,7 @@ class QuerySpec extends SpecCommon with PlaySpecification {
 
     "checkEdges" in {
       running(FakeApplication()) {
-        val json = Json.parse(s"""
+        val json = Json.parse( s"""
          [{"from": 0, "to": 1, "label": "$testLabelName"},
           {"from": 0, "to": 2, "label": "$testLabelName"}]
         """)
@@ -479,6 +554,50 @@ class QuerySpec extends SpecCommon with PlaySpecification {
         edgesTo must_== orderByTo
         ascOrderByTo must_== Seq(JsNumber(1), JsNumber(2))
         edgesTo.reverse must_== ascOrderByTo
+      }
+    }
+
+    "query with sampling" in {
+      running(FakeApplication()) {
+        val sampleSize = 2
+        val testId = 22
+        val bulkEdges = Seq(
+          edge"1442985659166 insert e $testId 122 $testLabelName",
+          edge"1442985659166 insert e $testId 222 $testLabelName",
+          edge"1442985659166 insert e $testId 322 $testLabelName",
+
+          edge"1442985659166 insert e $testId 922 $testLabelName2",
+          edge"1442985659166 insert e $testId 222 $testLabelName2",
+          edge"1442985659166 insert e $testId 322 $testLabelName2",
+
+          edge"1442985659166 insert e 122 1122 $testLabelName",
+          edge"1442985659166 insert e 122 1222 $testLabelName",
+          edge"1442985659166 insert e 122 1322 $testLabelName",
+          edge"1442985659166 insert e 222 2122 $testLabelName",
+          edge"1442985659166 insert e 222 2222 $testLabelName",
+          edge"1442985659166 insert e 222 2322 $testLabelName",
+          edge"1442985659166 insert e 322 3122 $testLabelName",
+          edge"1442985659166 insert e 322 3222 $testLabelName",
+          edge"1442985659166 insert e 322 3322 $testLabelName"
+        )
+
+        val req = FakeRequest(POST, "/graphs/edges/bulk").withBody(bulkEdges.mkString("\n"))
+        Await.result(route(req).get, HTTP_REQ_WAITING_TIME)
+
+        Thread.sleep(asyncFlushInterval)
+
+
+        val result1 = getEdges(queryWithSampling(testId, sampleSize))
+        println(Json.toJson(result1))
+        (result1 \ "results").as[List[JsValue]].size must equalTo(scala.math.min(sampleSize, bulkEdges.size))
+
+        val result2 = getEdges(twoStepQueryWithSampling(testId, sampleSize))
+        println(Json.toJson(result2))
+        (result2 \ "results").as[List[JsValue]].size must equalTo(scala.math.min(sampleSize * sampleSize, bulkEdges.size * bulkEdges.size))
+
+        val result3 = getEdges(twoQueryWithSampling(testId, sampleSize))
+        println(Json.toJson(result3))
+        (result3 \ "results").as[List[JsValue]].size must equalTo(sampleSize + 3) // edges in testLabelName2 = 3
       }
     }
   }


### PR DESCRIPTION
Taking suggestions from @SteamShon and @ummae into account, I've ran benchmark tests on three variations of sampling, and decided to go with _RNG Sampling_.
(Although I doubt that shuffling and taking n will have any realistic affect given that the number of queried edges is usually capped to thousands for service use.)
- Sampling from 100 edges (test end-to-end)
  ![screen shot 2015-12-01 at 3 21 11 pm](https://cloud.githubusercontent.com/assets/4621667/11493757/318a5e7c-983f-11e5-8ed8-73c3d66e27d8.png)
- Sampling from 1000 edges (test end-to-end)
  ![screen shot 2015-12-01 at 3 19 35 pm](https://cloud.githubusercontent.com/assets/4621667/11493745/13f5b032-983f-11e5-90ea-50f700335f9f.png)
- Sampling 10 from 1000, repeat 500K times (test sampling logic only)
  - Random Array Sampling: 6841 ms
  - Shuffle Sampling: 19927 ms
  - RNG Sampling: 6688 ms

Please refer to SamplingBenchmarkSpec.scala for some of the sampling implementations that were tested.
