### PR TITLE
handle json parsing error

### DIFF
--- a/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
+++ b/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
@@ -207,6 +207,46 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
   private def getEdges(key: RankingKey, duplicate: String="first"): Future[List[JsValue]] = {
     val labelName = counterModel.findById(key.policyId).get.action + labelPostfix
 
+//    val ids = (0 until BUCKET_SHARD_COUNT).map { idx =>
+//      s"${makeBucketShardKey(idx, key)}"
+//    }
+//
+//    val payload = Json.obj(
+//      "srcVertices" -> Json.arr(
+//        Json.obj(
+//          "serviceName" -> SERVICE_NAME,
+//          "columnName" -> BUCKET_COLUMN_NAME,
+//          "ids" -> ids
+//        )
+//      ),
+//      "steps" -> Json.arr(
+//        Json.obj(
+//          "step" -> Json.arr(
+//            Json.obj(
+//              "label" -> labelName,
+//              "duplicate" -> duplicate,
+//              "direction" -> "out",
+//              "offset" -> 0,
+//              "limit" -> -1,
+//              "interval" -> Json.obj(
+//                "from" -> Json.obj(
+//                  "time_unit" -> key.eq.tq.q.toString,
+//                  "time_value" -> key.eq.tq.ts
+//                ),
+//                "to" -> Json.obj(
+//                  "time_unit" -> key.eq.tq.q.toString,
+//                  "time_value" -> key.eq.tq.ts
+//                ),
+//                "scoring" -> Json.obj(
+//                  "score" -> 1
+//                )
+//              )
+//            )
+//          )
+//        )
+//      )
+//    )
+
     val ids = {
       (0 until BUCKET_SHARD_COUNT).map { shardIdx =>
         s""""${makeBucketShardKey(shardIdx, key)}""""
@@ -246,6 +286,7 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
     log.debug(strJs)
 
     val payload = Json.parse(strJs)
+
     wsClient.url(s"$s2graphUrl/graphs/getEdges").post(payload).map { resp =>
       resp.status match {
         case HttpStatus.SC_OK =>

--- a/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
+++ b/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
@@ -286,14 +286,21 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
        """.stripMargin
     log.debug(strJs)
 
-    val payload = Json.parse(strJs)
-    wsClient.url(s"$s2graphReadOnlyUrl/graphs/getEdges").post(payload).map { resp =>
-      resp.status match {
-        case HttpStatus.SC_OK =>
-          (resp.json \ "results").asOpt[List[JsValue]].getOrElse(Nil)
-        case _ =>
-          throw new RuntimeException(s"failed getEdges. errCode: ${resp.status}, body: ${resp.body}, query: $payload")
-      }
+    Try {
+      Json.parse(strJs)
+    } match {
+      case Success(payload) =>
+        wsClient.url(s"$s2graphReadOnlyUrl/graphs/getEdges").post(payload).map { resp =>
+          resp.status match {
+            case HttpStatus.SC_OK =>
+              (resp.json \ "results").asOpt[List[JsValue]].getOrElse(Nil)
+            case _ =>
+              throw new RuntimeException(s"failed getEdges. errCode: ${resp.status}, body: ${resp.body}, query: $payload")
+          }
+        }
+      case Failure(ex) =>
+        log.error(s"$ex")
+        Future.successful(Nil)
     }
   }
 

--- a/s2counter_loader/build.sbt
+++ b/s2counter_loader/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "16.0.1"
 )
 
-scalaVersion := "2.10.6"
+crossScalaVersions := Seq("2.10.6")
 
 fork := true
 


### PR DESCRIPTION
Motivation:
Currently, `JsonParseException` is raised when wrong data is inserted into `RankingCounterStreaming` job.

Modification:
Catching and handling `JsonParseException` in `RankingStorageGraph`.

Result:
Logging and skipping the exception.
