### PR TITLE
S2GRAPH-21: Change PostProcessBenchmarkSpec not to store and fetch test data from storage

### DIFF
--- a/test/benchmark/BenchmarkCommon.scala
+++ b/test/benchmark/BenchmarkCommon.scala
@@ -15,4 +15,13 @@ trait BenchmarkCommon extends Specification {
     println(s"$wrapStr\n$prefix: took ${endTs - startTs} ms$wrapStr")
     ret
   }
+
+  def durationWithReturn[T](prefix: String = "")(block: => T): (T, Long) = {
+    val startTs = System.currentTimeMillis()
+    val ret = block
+    val endTs = System.currentTimeMillis()
+    val duration = endTs - startTs
+//    println(s"$wrapStr\n$prefix: took $duration ms$wrapStr")
+    (ret, duration)
+  }
 }

--- a/test/benchmark/PostProcessBenchmarkSpec.scala
+++ b/test/benchmark/PostProcessBenchmarkSpec.scala
@@ -1,127 +1,106 @@
 package benchmark
 
-import com.kakao.s2graph.core.mysqls.Label
-import com.kakao.s2graph.core.{Graph, Management}
+import com.kakao.s2graph.core._
+import com.kakao.s2graph.core.types.{HBaseType, InnerVal, SourceVertexId}
 import controllers._
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.{FakeApplication, FakeRequest, PlaySpecification}
+import scala.util.Random
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
-/**
-  * Created by hsleep(honeysleep@gmail.com) on 2015. 11. 6..
-  */
 class PostProcessBenchmarkSpec extends SpecCommon with BenchmarkCommon with PlaySpecification {
   sequential
+  object Parser extends RequestParser
+  val numOfTry = 10
+  val steps = Seq(100, 1000, 10000)
 
-  import Helper._
-
-  init()
-
-  override def init() = {
-    running(FakeApplication()) {
-      println("[init start]: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
-      Management.deleteService(testServiceName)
-
-      // 1. createService
-      val result = AdminController.createServiceInner(Json.parse(createService))
-      println(s">> Service created : $createService, $result")
-
-      val labelNames = Map(
-        testLabelNameWeak -> testLabelNameWeakCreate
-      )
-
-      for {
-        (labelName, create) <- labelNames
-      } {
-        Management.deleteLabel(labelName)
-        Label.findByName(labelName, useCache = false) match {
-          case None =>
-            AdminController.createLabelInner(Json.parse(create))
-          case Some(label) =>
-            println(s">> Label already exist: $create, $label")
-        }
-      }
-
-      // create edges
-      val bulkEdges: String = (0 until 500).map { i =>
-        edge"${System.currentTimeMillis()} insert e 0 $i $testLabelNameWeak"($(weight=i))
-      }.mkString("\n")
-
-      val jsResult = contentAsJson(EdgeController.mutateAndPublish(bulkEdges, withWait = true))
-
-      println("[init end]: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
-    }
+  def createQueryRequestWithResult(queryRequest: QueryRequest, n: Int): QueryRequestWithResult = {
+    val edgeWithScoreLs = for {
+      i <- (0 until n)
+      s = Seq(System.currentTimeMillis(), "insert", "e", "0", i, testLabelNameWeak).mkString("\t")
+      edge <- Graph.toEdge(s)
+      score = Random.nextDouble()
+    } yield EdgeWithScore(edge, score)
+    QueryRequestWithResult(queryRequest, QueryResult(edgeWithScoreLs))
   }
+
+  def dummyVertex() = Vertex(SourceVertexId(0, InnerVal.withStr("0", HBaseType.DEFAULT_VERSION)))
 
   def getEdges(queryJson: JsValue): JsValue = {
     val ret = route(FakeRequest(POST, "/graphs/getEdges").withJsonBody(queryJson)).get
     contentAsJson(ret)
   }
 
+  def runTC(prefix: String)(strJs: String): Boolean = {
+    println(Seq("*" * 50, s"$prefix, average with $numOfTry try", "*" * 50).mkString("\n"))
+
+
+    val js = Json.parse(strJs)
+
+    val q = Parser.toQuery(js)
+
+    val queryRequest = QueryRequest(q, 1, q.vertices.head, q.steps.head.queryParams.head)
+    for {
+      step <- steps
+      n <- (step until step * 10 by step)
+    } {
+      var total = 0L
+      for {
+        i <- (0 until numOfTry)
+      } {
+        val queryRequestWithResult = createQueryRequestWithResult(queryRequest, n)
+        val logMsg = s"toSimpleVertexArrJson new: n = $n"
+        val (_, elapsed) = durationWithReturn(logMsg) {
+          PostProcess.toSimpleVertexArrJson(Seq(queryRequestWithResult), Nil)
+        }
+        total += elapsed
+      }
+      println(Seq(s"n = $n", s" average ${total / numOfTry.toDouble} ms").mkString(","))
+    }
+    true
+  }
+
   val s2: Graph = com.kakao.s2graph.rest.Global.s2graph
 
-//  "test performance of getEdges orderBy" >> {
-//    running(FakeApplication()) {
-//      val strJs =
-//        s"""
-//           |{
-//           |  "orderBy": [
-//           |    {"score": "DESC"},
-//           |    {"timestamp": "DESC"}
-//           |  ],
-//           |  "srcVertices": [
-//           |    {
-//           |      "serviceName": "$testServiceName",
-//           |      "columnName": "$testColumnName",
-//           |      "ids": [0]
-//           |    }
-//           |  ],
-//           |  "steps": [
-//           |    {
-//           |      "step": [
-//           |        {
-//           |          "cacheTTL": 60000,
-//           |          "label": "$testLabelNameWeak",
-//           |          "offset": 0,
-//           |          "limit": -1,
-//           |          "direction": "out",
-//           |          "scoring": [
-//           |            {"weight": 1}
-//           |          ]
-//           |        }
-//           |      ]
-//           |    }
-//           |  ]
-//           |}
-//      """.stripMargin
-//
-//      object Parser extends RequestParser
-//
-//      val js = Json.parse(strJs)
-//
-//      val q = Parser.toQuery(js)
-//
-//      val queryResultLs = Await.result(s2.getEdges(q), 1 seconds)
-//
-//      val resultJs = PostProcess.toSimpleVertexArrJson(queryResultLs)
-//
-//      (resultJs \ "size").as[Int] must_== 500
-//
-//      (0 to 5) foreach { _ =>
-//        duration("toSimpleVertexArrJson new orderBy") {
-//          (0 to 1000) foreach { _ =>
-//            PostProcess.toSimpleVertexArrJson(queryResultLs, Nil)
-//          }
-//        }
-//      }
-//
-//      (resultJs \ "size").as[Int] must_== 500
-//    }
-//  }
+  "test performance of PostProcess with orderBy" >> {
+    running(FakeApplication()) {
+      val strJs =
+        s"""
+           |{
+           |  "orderBy": [
+           |    {"score": "DESC"},
+           |    {"timestamp": "DESC"}
+           |  ],
+           |  "srcVertices": [
+           |    {
+           |      "serviceName": "$testServiceName",
+           |      "columnName": "$testColumnName",
+           |      "ids": [0]
+           |    }
+           |  ],
+           |  "steps": [
+           |    {
+           |      "step": [
+           |        {
+           |          "cacheTTL": 60000,
+           |          "label": "$testLabelNameWeak",
+           |          "offset": 0,
+           |          "limit": -1,
+           |          "direction": "out",
+           |          "scoring": [
+           |            {"weight": 1}
+           |          ]
+           |        }
+           |      ]
+           |    }
+           |  ]
+           |}
+      """.stripMargin
 
-  "test performance of getEdges" >> {
+      runTC("test performance of PostProcess with orderBy")(strJs)
+    }
+  }
+
+  "test performance of PostProcess with score" >> {
     running(FakeApplication()) {
       val strJs =
         s"""
@@ -152,87 +131,43 @@ class PostProcessBenchmarkSpec extends SpecCommon with BenchmarkCommon with Play
            |}
       """.stripMargin
 
-      object Parser extends RequestParser
-
-      val js = Json.parse(strJs)
-
-      val q = Parser.toQuery(js)
-
-      val queryResultLs = Await.result(s2.getEdges(q), 1 seconds)
-
-      val resultJs = PostProcess.toSimpleVertexArrJson(queryResultLs, Nil)
-
-      (0 to 5) foreach { _ =>
-        duration("toSimpleVertexArrJson new") {
-          (0 to 1000) foreach { _ =>
-            PostProcess.toSimpleVertexArrJson(queryResultLs, Nil)
-          }
-        }
-      }
-
-      (resultJs \ "size").as[Int] must_== 500
+      runTC("test performance of PostProcess with score")(strJs)
     }
   }
 
-//  "test performance of getEdges withScore=false" >> {
-//    running(FakeApplication()) {
-//      val strJs =
-//        s"""
-//           |{
-//           |  "withScore": false,
-//           |  "srcVertices": [
-//           |    {
-//           |      "serviceName": "$testServiceName",
-//           |      "columnName": "$testColumnName",
-//           |      "ids": [0]
-//           |    }
-//           |  ],
-//           |  "steps": [
-//           |    {
-//           |      "step": [
-//           |        {
-//           |          "cacheTTL": 60000,
-//           |          "label": "$testLabelNameWeak",
-//           |          "offset": 0,
-//           |          "limit": -1,
-//           |          "direction": "out",
-//           |          "scoring": [
-//           |            {"weight": 1}
-//           |          ]
-//           |        }
-//           |      ]
-//           |    }
-//           |  ]
-//           |}
-//      """.stripMargin
-//
-//      object Parser extends RequestParser
-//
-//      val js = Json.parse(strJs)
-//
-//      val q = Parser.toQuery(js)
-//
-//      val queryResultLs = Await.result(s2.getEdges(q), 1 seconds)
-//
-//      val resultJs = PostProcess.toSimpleVertexArrJson(queryResultLs)
-//
-//      (resultJs \ "size").as[Int] must_== 500
-//
-//      (0 to 5) foreach { _ =>
-//        duration("toSimpleVertexArrJson withScore=false org") {
-//          (0 to 1000) foreach { _ =>
-//            PostProcess.toSimpleVertexArrJsonOrg(queryResultLs, Nil)
-//          }
-//        }
-//
-//        duration("toSimpleVertexArrJson withScore=false new") {
-//          (0 to 1000) foreach { _ =>
-//            PostProcess.toSimpleVertexArrJson(queryResultLs, Nil)
-//          }
-//        }
-//      }
-//
-//      (resultJs \ "size").as[Int] must_== 500
-//    }
-//  }
+  "test performance of PostProcess without score" >> {
+    running(FakeApplication()) {
+      val strJs =
+        s"""
+           |{
+           |  "withScore": false,
+           |  "srcVertices": [
+           |    {
+           |      "serviceName": "$testServiceName",
+           |      "columnName": "$testColumnName",
+           |      "ids": [0]
+           |    }
+           |  ],
+           |  "steps": [
+           |    {
+           |      "step": [
+           |        {
+           |          "cacheTTL": 60000,
+           |          "label": "$testLabelNameWeak",
+           |          "offset": 0,
+           |          "limit": -1,
+           |          "direction": "out",
+           |          "scoring": [
+           |            {"weight": 1}
+           |          ]
+           |        }
+           |      ]
+           |    }
+           |  ]
+           |}
+      """.stripMargin
+
+      runTC("test performance of PostProcess without score")(strJs)
+    }
+  }
 }


### PR DESCRIPTION
- removed re-create service/label on setup phase of PostProcessBenchmarkSpec.
- change to use mocked query result instead of insert test data and fetching it from storage.
