### PR TITLE
Added edge's property for RankingCounter

### DIFF
--- a/dev_support/docker-compose.yml
+++ b/dev_support/docker-compose.yml
@@ -2,9 +2,6 @@ graph:
     image: s2rest_play:0.12.1-SNAPSHOT
     container_name: graph
     net: container:graph_hbase
-    links:
-        - graph_mysql
-        - graph_hbase
 
 graph_mysql:
     build: graph_mysql

--- a/s2counter_core/src/main/scala/s2/counter/core/v2/ExactStorageGraph.scala
+++ b/s2counter_core/src/main/scala/s2/counter/core/v2/ExactStorageGraph.scala
@@ -115,7 +115,6 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
                   (implicit ex: ExecutionContext): Future[Seq[FetchedCountsGrouped]] = {
     val labelName = policy.action + labelPostfix
     val label = Label.findByName(labelName).get
-//    val label = labelModel.findByName(labelName).get
 
     val ids = Json.toJson(items)
 
@@ -186,9 +185,7 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
       resp.status match {
         case HttpStatus.SC_OK =>
           val respJs = resp.json
-//          println(respJs)
           val keyWithValues = (respJs \ "results").as[Seq[JsValue]].map { result =>
-//            println(s"result: $result")
             resultToExactKeyValues(policy, result)
           }.groupBy(_._1).mapValues(seq => seq.map(_._2).toMap.groupBy { case (eq, v) => (eq.tq.q, eq.dimKeyValues) })
           for {
@@ -198,7 +195,6 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
           }
         case n: Int =>
           log.warn(s"getEdges status($n): $reqJsStr")
-//          println(s"getEdges status($n): $reqJsStr")
           Nil
       }
     }
@@ -240,7 +236,6 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
           Json.obj("step" -> stepLs)
         }
         val query = Json.obj("srcVertices" -> Json.arr(src), "steps" -> Json.arr(step))
-        //    println(s"query: ${query.toString()}")
 
         wsClient.url(s"$s2graphReadOnlyUrl/graphs/getEdges").post(query).map { resp =>
           resp.status match {
@@ -270,7 +265,6 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
       for {
         (key, eqs) <- queries
       } yield {
-//        println(s"$key $eqs")
         getInner(policy, key, eqs)
       }
     }

--- a/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
+++ b/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
@@ -317,6 +317,7 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
                 "label" -> labelName,
                 "props" -> Json.obj(
                   "time_unit" -> rankingKey.eq.tq.q.toString,
+                  "time_value" -> rankingKey.eq.tq.ts,
                   "date_time" -> rankingKey.eq.tq.dateTime
                 )
               )

--- a/s2counter_core/src/test/resources/application.conf
+++ b/s2counter_core/src/test/resources/application.conf
@@ -74,4 +74,5 @@ profile.cache.max.size=1000000
 profile.prefetch.size=100
 
 # s2graph
-s2graph.url = "http://localhost:9000"
+s2graph.url = "http://"${host}":9000"
+

--- a/s2counter_core/src/test/scala/s2/counter/core/RankingCounterSpec.scala
+++ b/s2counter_core/src/test/scala/s2/counter/core/RankingCounterSpec.scala
@@ -26,40 +26,7 @@ class RankingCounterSpec extends Specification with BeforeAfterAll {
 
   val s2config = new S2CounterConfig(config)
 
-//  val rankingCounterV1 = new RankingCounter(config, new RankingStorageV1(config))
-//  val rankingCounterV2 = new RankingCounter(config, new RankingStorageV2(config))
   val rankingCounterV2 = new RankingCounter(config, new RankingStorageGraph(config))
-
-//  "RankingCounterV1" >> {
-//    val policy = counterModel.findByServiceAction("test", "test_action", useCache = false).get
-//    val rankingKey = RankingKey(policy.id, policy.version, ExactQualifier(TimedQualifier(IntervalUnit.TOTAL, 0L), Map.empty[String, String]))
-//    "get top k" >> {
-//      val result = rankingCounterV1.getTopK(rankingKey, 100)
-//
-//      println(result)
-//
-//      result must not be empty
-//    }
-//
-//    "get and increment" >> {
-//      val result = rankingCounterV1.getTopK(rankingKey, 100).get
-//
-//      val value = 2d
-//      val contents = {
-//        for {
-//          (item, score) <- result.values
-//        } yield {
-//          item -> RankingValue(score + value, value)
-//        }
-//      }.toMap
-//      rankingCounterV1.update(rankingKey, contents, 100)
-//
-//      val result2 = rankingCounterV1.getTopK(rankingKey, 100).get
-//
-//      result2.totalScore must_== result.totalScore + contents.values.map(_.increment).sum
-//      result2.values must containTheSameElementsAs(result.values.map { case (k, v) => (k, v + value) })
-//    }
-//  }
 
   val service = "test"
   val action = "test_case"
@@ -116,7 +83,7 @@ class RankingCounterSpec extends Specification with BeforeAfterAll {
 
   "RankingCounterV2" >> {
     "get top k" >> {
-      val policy = counterModel.findByServiceAction(service, action, useCache = true).get
+      val policy = counterModel.findByServiceAction(service, action, useCache = false).get
 
       val rankingKey = RankingKey(policy.id, policy.version, ExactQualifier(TimedQualifier(IntervalUnit.TOTAL, 0L), Map.empty[String, String]))
 

--- a/s2counter_loader/src/main/scala/s2/counter/stream/ExactCounterStreaming.scala
+++ b/s2counter_loader/src/main/scala/s2/counter/stream/ExactCounterStreaming.scala
@@ -2,7 +2,6 @@ package s2.counter.stream
 
 import kafka.serializer.StringDecoder
 import org.apache.spark.streaming.Durations._
-import org.apache.spark.streaming.kafka.KafkaRDDFunctions.rddToKafkaRDDFunctions
 import org.apache.spark.streaming.kafka.{HasOffsetRanges, StreamHelper}
 import s2.config.{S2ConfigFactory, S2CounterConfig, StreamingConfig}
 import s2.counter.core.CounterFunctions
@@ -26,7 +25,6 @@ object ExactCounterStreaming extends SparkApp with WithKafka {
   val strInputTopics = inputTopics.mkString(",")
   val groupId = buildKafkaGroupId(strInputTopics, "counter_v2")
   val kafkaParam = Map(
-//    "auto.offset.reset" -> "smallest",
     "group.id" -> groupId,
     "metadata.broker.list" -> StreamingConfig.KAFKA_BROKERS,
     "zookeeper.connect" -> StreamingConfig.KAFKA_ZOOKEEPER,
@@ -62,19 +60,6 @@ object ExactCounterStreaming extends SparkApp with WithKafka {
       }
 
       streamHelper.commitConsumerOffsets(nextRdd.asInstanceOf[HasOffsetRanges])
-//      val offsets = rdd.asInstanceOf[HasOffsetRanges].offsetRanges
-//
-//      val exactRDD = CounterFunctions.makeExactRdd(rdd, offsets.length)
-//
-//      // for at-least once semantic
-//      exactRDD.foreachPartitionWithIndex { (i, part) =>
-//        // update exact counter
-//        val trxLogs = CounterFunctions.updateExactCounter(part.toSeq, acc)
-//        CounterFunctions.produceTrxLog(trxLogs)
-//
-//        // commit offset range
-//        streamHelper.commitConsumerOffset(offsets(i))
-//      }
     }
 
     ssc.start()

--- a/s2counter_loader/src/main/scala/s2/counter/stream/RankingCounterStreaming.scala
+++ b/s2counter_loader/src/main/scala/s2/counter/stream/RankingCounterStreaming.scala
@@ -59,13 +59,6 @@ object RankingCounterStreaming extends SparkApp with WithKafka {
       }
 
       streamHelper.commitConsumerOffsets(nextRdd.asInstanceOf[HasOffsetRanges])
-//      CounterFunctions.makeRankingRdd(rdd, offsets.length).foreachPartitionWithIndex { (i, part) =>
-//        // update ranking counter
-//        CounterFunctions.updateRankingCounter(part, acc)
-//
-//        // commit offset range
-//        streamHelper.commitConsumerOffset(offsets(i))
-//      }
     }
 
     ssc.start()


### PR DESCRIPTION
**Motivation**
Currently RankingStorageGraph does not store the dimension property on its edge. Therefore, we can't use the dimension property in `groupBy` or `where` clauses for the ranking counter's query. If dimension property is stored on the ranking counter edge, it is very useful for querying.

**Modification**
Changed RankingStorageGraph to store the dimension property on its edge.

**Result**
We can use the dimension property in groupBy or where clause for ranking counter query.
