### PR TITLE
Separate deleteAll operation from others(insert/delete/update) on mutateEdges

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/Graph.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/Graph.scala
@@ -36,6 +36,7 @@ object Graph {
     "hbase.rpcs.buffered_flush_interval" -> java.lang.Short.valueOf(100.toShort),
     "hbase.rpc.timeout" -> java.lang.Integer.valueOf(1000),
     "max.retry.number" -> java.lang.Integer.valueOf(100),
+    "lock.expire.time" -> java.lang.Integer.valueOf(1000 * 60 * 10),
     "max.back.off" -> java.lang.Integer.valueOf(100),
     "hbase.fail.prob" -> java.lang.Double.valueOf(-0.1),
     "delete.all.fetch.size" -> java.lang.Integer.valueOf(1000),


### PR DESCRIPTION
- Increase lock expire time 10m
- Separate `deleteAll` operation from others(insert/delete/update) on `mutateEdges`
- When Lock is expired, set lock ts as current time
