### PR TITLE
Feature/query with specific bucket

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/JSONParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/JSONParser.scala
@@ -31,7 +31,7 @@ trait JSONParser {
                 case InnerVal.LONG => JsNumber(d.toLong)
                 case InnerVal.FLOAT => JsNumber(d.toDouble)
                 case InnerVal.DOUBLE => JsNumber(d.toDouble)
-                case _ => throw new RuntimeException("innerValToJsValue invalid")
+                case _ => throw new RuntimeException(s"$innerVal, $dType => $dataType")
               }
             case num: BigDecimal =>
               //              JsNumber(num)
@@ -43,19 +43,18 @@ trait JSONParser {
                 case InnerVal.LONG => JsNumber(num.toLong)
                 case InnerVal.FLOAT => JsNumber(num.toDouble)
                 case InnerVal.DOUBLE => JsNumber(num.toDouble)
-                case _ => throw new RuntimeException("innerValToJsValue invalid")
+                case _ => throw new RuntimeException(s"$innerVal, $dType => $dataType")
               }
             //              JsNumber(num.toLong)
-            case _ => throw new RuntimeException("innerValToJsValue invalid")
+            case _ => throw new RuntimeException(s"$innerVal, Numeric Unknown => $dataType")
           }
         //          JsNumber(InnerVal.scaleNumber(innerVal.asInstanceOf[BigDecimal], dType))
-        case _ =>
-          throw new RuntimeException(s"innerVal $innerVal to JsValue with type $dType")
+        case _ => throw new RuntimeException(s"$innerVal, Unknown => $dataType")
       }
       Some(jsValue)
     } catch {
       case e: Exception =>
-//        logger.info(s"JSONParser.innerValToJsValue: $innerVal, $dataType")
+        logger.info(s"JSONParser.innerValToJsValue: $e")
         None
     }
   }

--- a/s2core/src/main/scala/com/kakao/s2graph/core/JSONParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/JSONParser.scala
@@ -55,7 +55,7 @@ trait JSONParser {
       Some(jsValue)
     } catch {
       case e: Exception =>
-        logger.info(s"JSONParser.innerValToJsValue: $innerVal, $dataType")
+//        logger.info(s"JSONParser.innerValToJsValue: $innerVal, $dataType")
         None
     }
   }

--- a/s2core/src/main/scala/com/kakao/s2graph/core/mysqls/Experiment.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/mysqls/Experiment.scala
@@ -86,8 +86,8 @@ case class Experiment(id: Option[Int],
   } yield range -> bucket
 
 
-  def findBucket(uuid: String, impressionIdOpt: Option[String] = None): Option[Bucket] = {
-    impressionIdOpt match {
+  def findBucket(uuid: String, impIdOpt: Option[String] = None): Option[Bucket] = {
+    impIdOpt match {
       case Some(impId) => Bucket.findByImpressionId(impId)
       case None =>
         val seed = experimentType match {

--- a/s2core/src/main/scala/com/kakao/s2graph/core/mysqls/Experiment.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/mysqls/Experiment.scala
@@ -41,7 +41,7 @@ object Experiment extends Model[Experiment] {
     )
   }
 
-  val findVar = """\$\{(.*?)\}""".r
+  val findVar = """\"?\$\{(.*?)\}\"?""".r
   val num = """(-?[0-9]+)\s*?(hour|day)""".r
 
   val hour = 60 * 60 * 1000

--- a/s2core/src/test/scala/com/kakao/s2graph/core/parsers/WhereParserTest.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/parsers/WhereParserTest.scala
@@ -179,9 +179,9 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
     val body = """{
         	"day": ${1day},
           "hour": ${1hour},
-          "-day": ${-10 day},
+          "-day": "${-10 day}",
           "-hour": ${-10 hour},
-          "now": ${now}
+          "now": "${now}"
         }
       """
 

--- a/s2core/src/test/scala/com/kakao/s2graph/core/parsers/WhereParserTest.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/parsers/WhereParserTest.scala
@@ -51,121 +51,121 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
     }
     ret shouldBe expected
   }
-//
-//  test("check where clause not nested") {
-//    for {
-//      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
-//    } {
-//      /** test for each version */
-//      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
-//      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
-//      val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, propsInner)
-//      val f = validate(label)(edge) _
-//
-//      /** labelName label is long-long relation */
-//      f(s"_to=${tgtVertex.innerId.toString}")(true)
-//
-//      // currently this throw exception since label`s _to is long type.
-//      f(s"_to=19230495")(false)
-//      f(s"_to!=19230495")(true)
-//    }
-//  }
-//
-//  test("check where clause nested") {
-//    for {
-//      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
-//    } {
-//      /** test for each version */
-//      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
-//      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
-//      val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, propsInner)
-//
-//      val f = validate(label)(edge) _
-//
-//      // time == 3
-//      f("time >= 3")(true)
-//      f("time > 2")(true)
-//      f("time <= 3")(true)
-//      f("time < 2")(false)
-//
-//      f("(time in (1, 2, 3) and is_blocked = true) or is_hidden = false")(false)
-//      f("(time in (1, 2, 3) or is_blocked = true) or is_hidden = false")(true)
-//      f("(time in (1, 2, 3) and is_blocked = true) or is_hidden = true")(true)
-//      f("(time in (1, 2, 3) or is_blocked = true) and is_hidden = true")(true)
-//
-//      f("((time in (  1, 2, 3) and weight between 1 and 10) or is_hidden=false)")(true)
-//      f("(time in (1, 2, 4 ) or weight between 1 and 9) or (is_hidden = false)")(false)
-//      f("(time in ( 1,2,4 ) or weight between 1 and 9) or is_hidden= true")(true)
-//      f("(time in (1,2,3) or weight between 1 and 10) and is_hidden =false")(false)
-//    }
-//  }
-//
-//  test("check where clause with from/to long") {
-//    for {
-//      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
-//    } {
-//      /** test for each version */
-//      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
-//      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
-//      val labelWithDirection = if (schemaVer == VERSION2) labelWithDirV2 else labelWithDir
-//      val edge = Edge(srcVertex, tgtVertex, labelWithDirection, 0.toByte, ts, propsInner)
-//      val lname = if (schemaVer == VERSION2) labelNameV2 else labelName
-//      val f = validate(label)(edge) _
-//
-//      f(s"_from = -1 or _to = ${tgtVertex.innerId.value}")(true)
-//      f(s"_from = ${srcVertex.innerId.value} and _to = ${tgtVertex.innerId.value}")(true)
-//      f(s"_from = ${tgtVertex.innerId.value} and _to = 102934")(false)
-//      f(s"_from = -1")(false)
-//      f(s"_from in (-1, -0.1)")(false)
-//    }
-//  }
-//
-//
-//  test("check where clause with parent") {
-//    for {
-//      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
-//    } {
-//      /** test for each version */
-//      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 1, "name" -> "abc")
-//      val parentJs = Json.obj("is_hidden" -> false, "is_blocked" -> false, "weight" -> 20, "time" -> 3, "name" -> "a")
-//
-//      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
-//      val parentPropsInner = Management.toProps(label, parentJs.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
-//
-//      val grandParentEdge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, parentPropsInner)
-//      val parentEdge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, parentPropsInner,
-//        parentEdges = Seq(EdgeWithScore(grandParentEdge, 1.0)))
-//      val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, propsInner,
-//        parentEdges = Seq(EdgeWithScore(parentEdge, 1.0)))
-//
-//      println(edge.toString)
-//      println(parentEdge.toString)
-//      println(grandParentEdge.toString)
-//
-//      val f = validate(label)(edge) _
-//
-//      // Compare edge's prop(`_from`) with edge's prop(`name`)
-//      f("_from = 1")(true)
-//      f("_to = 2")(true)
-//      f("_from = 123")(false)
-//      f("_from = time")(true)
-//
-//      // Compare edge's prop(`weight`) with edge's prop(`time`)
-//      f("weight = time")(false)
-//      f("weight = is_blocked")(false)
-//
-//      // Compare edge's prop(`weight`) with parent edge's prop(`weight`)
-//      f("_parent.is_blocked = is_blocked")(true)
-//      f("is_hidden = _parent.is_hidden")(false)
-//      f("_parent.weight = weight")(false)
-//
-//      // Compare edge's prop(`is_hidden`) with parent of parent edge's prop(`is_hidden`)
-//      f("_parent._parent.is_hidden = is_hidden")(false)
-//      f("_parent._parent.is_blocked = is_blocked")(true)
-//      f("_parent._parent.weight = weight")(false)
-//      f("_parent._parent.weight = _parent.weight")(true)
-//    }
-//  }
+
+  test("check where clause not nested") {
+    for {
+      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
+    } {
+      /** test for each version */
+      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
+      val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, propsInner)
+      val f = validate(label)(edge) _
+
+      /** labelName label is long-long relation */
+      f(s"_to=${tgtVertex.innerId.toString}")(true)
+
+      // currently this throw exception since label`s _to is long type.
+      f(s"_to=19230495")(false)
+      f(s"_to!=19230495")(true)
+    }
+  }
+
+  test("check where clause nested") {
+    for {
+      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
+    } {
+      /** test for each version */
+      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
+      val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, propsInner)
+
+      val f = validate(label)(edge) _
+
+      // time == 3
+      f("time >= 3")(true)
+      f("time > 2")(true)
+      f("time <= 3")(true)
+      f("time < 2")(false)
+
+      f("(time in (1, 2, 3) and is_blocked = true) or is_hidden = false")(false)
+      f("(time in (1, 2, 3) or is_blocked = true) or is_hidden = false")(true)
+      f("(time in (1, 2, 3) and is_blocked = true) or is_hidden = true")(true)
+      f("(time in (1, 2, 3) or is_blocked = true) and is_hidden = true")(true)
+
+      f("((time in (  1, 2, 3) and weight between 1 and 10) or is_hidden=false)")(true)
+      f("(time in (1, 2, 4 ) or weight between 1 and 9) or (is_hidden = false)")(false)
+      f("(time in ( 1,2,4 ) or weight between 1 and 9) or is_hidden= true")(true)
+      f("(time in (1,2,3) or weight between 1 and 10) and is_hidden =false")(false)
+    }
+  }
+
+  test("check where clause with from/to long") {
+    for {
+      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
+    } {
+      /** test for each version */
+      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 3, "name" -> "abc")
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
+      val labelWithDirection = if (schemaVer == VERSION2) labelWithDirV2 else labelWithDir
+      val edge = Edge(srcVertex, tgtVertex, labelWithDirection, 0.toByte, ts, propsInner)
+      val lname = if (schemaVer == VERSION2) labelNameV2 else labelName
+      val f = validate(label)(edge) _
+
+      f(s"_from = -1 or _to = ${tgtVertex.innerId.value}")(true)
+      f(s"_from = ${srcVertex.innerId.value} and _to = ${tgtVertex.innerId.value}")(true)
+      f(s"_from = ${tgtVertex.innerId.value} and _to = 102934")(false)
+      f(s"_from = -1")(false)
+      f(s"_from in (-1, -0.1)")(false)
+    }
+  }
+
+
+  test("check where clause with parent") {
+    for {
+      (srcId, tgtId, srcIdStr, tgtIdStr, srcVertex, tgtVertex, srcVertexStr, tgtVertexStr, schemaVer) <- List(ids(VERSION1), ids(VERSION2))
+    } {
+      /** test for each version */
+      val js = Json.obj("is_hidden" -> true, "is_blocked" -> false, "weight" -> 10, "time" -> 1, "name" -> "abc")
+      val parentJs = Json.obj("is_hidden" -> false, "is_blocked" -> false, "weight" -> 20, "time" -> 3, "name" -> "a")
+
+      val propsInner = Management.toProps(label, js.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
+      val parentPropsInner = Management.toProps(label, parentJs.fields).map { case (k, v) => k -> InnerValLikeWithTs(v, ts) }.toMap + dummyTs
+
+      val grandParentEdge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, parentPropsInner)
+      val parentEdge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, parentPropsInner,
+        parentEdges = Seq(EdgeWithScore(grandParentEdge, 1.0)))
+      val edge = Edge(srcVertex, tgtVertex, labelWithDir, 0.toByte, ts, propsInner,
+        parentEdges = Seq(EdgeWithScore(parentEdge, 1.0)))
+
+      println(edge.toString)
+      println(parentEdge.toString)
+      println(grandParentEdge.toString)
+
+      val f = validate(label)(edge) _
+
+      // Compare edge's prop(`_from`) with edge's prop(`name`)
+      f("_from = 1")(true)
+      f("_to = 2")(true)
+      f("_from = 123")(false)
+      f("_from = time")(true)
+
+      // Compare edge's prop(`weight`) with edge's prop(`time`)
+      f("weight = time")(false)
+      f("weight = is_blocked")(false)
+
+      // Compare edge's prop(`weight`) with parent edge's prop(`weight`)
+      f("_parent.is_blocked = is_blocked")(true)
+      f("is_hidden = _parent.is_hidden")(false)
+      f("_parent.weight = weight")(false)
+
+      // Compare edge's prop(`is_hidden`) with parent of parent edge's prop(`is_hidden`)
+      f("_parent._parent.is_hidden = is_hidden")(false)
+      f("_parent._parent.is_blocked = is_blocked")(true)
+      f("_parent._parent.weight = weight")(false)
+      f("_parent._parent.weight = _parent.weight")(true)
+    }
+  }
 
   test("replace reserved") {
     val ts = 0

--- a/s2rest_netty/src/main/scala/Server.scala
+++ b/s2rest_netty/src/main/scala/Server.scala
@@ -1,9 +1,12 @@
 package com.kakao.s2graph.rest.netty
 
+import java.util.Map.Entry
 import java.util.concurrent.Executors
+import java.util.function.Consumer
 
 import com.kakao.s2graph.core.GraphExceptions.BadQueryException
 import com.kakao.s2graph.core._
+import com.kakao.s2graph.core.mysqls.Experiment
 import com.kakao.s2graph.core.rest.RestHandler.HandlerResult
 import com.kakao.s2graph.core.rest._
 import com.kakao.s2graph.core.utils.Extensions._
@@ -20,6 +23,7 @@ import io.netty.handler.codec.http._
 import io.netty.handler.logging.{LogLevel, LoggingHandler}
 import io.netty.util.CharsetUtil
 import play.api.libs.json._
+
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.io.Source
@@ -132,7 +136,7 @@ class S2RestHandler(s2rest: RestHandler)(implicit ec: ExecutionContext) extends 
         val jsonString = req.content.toString(CharsetUtil.UTF_8)
         val jsQuery = Json.parse(jsonString)
 
-        val result = s2rest.doPost(uri, jsQuery)
+        val result = s2rest.doPost(uri, jsQuery, Option(req.headers().get(Experiment.impressionKey)))
         toResponse(ctx, req, jsQuery, result, startedAt)
 
       case _ =>

--- a/s2rest_play/app/controllers/ExperimentController.scala
+++ b/s2rest_play/app/controllers/ExperimentController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 
+import com.kakao.s2graph.core.mysqls.Experiment
 import com.kakao.s2graph.core.rest.RestHandler
 import play.api.mvc._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -13,7 +14,7 @@ object ExperimentController extends Controller {
 
   def experiment(accessToken: String, experimentName: String, uuid: String) = withHeaderAsync(parse.anyContent) { request =>
     val body = request.body.asJson.get
-    val res = rest.doPost(request.uri, body)
+    val res = rest.doPost(request.uri, body, request.headers.get(Experiment.impressionKey))
 
     res.body.map { case js =>
       val headers = res.headers :+ ("result_size" -> rest.calcSize(js).toString)

--- a/s2rest_play/app/controllers/QueryController.scala
+++ b/s2rest_play/app/controllers/QueryController.scala
@@ -2,6 +2,7 @@ package controllers
 
 
 import com.kakao.s2graph.core._
+import com.kakao.s2graph.core.mysqls.Experiment
 import com.kakao.s2graph.core.rest.RestHandler
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Controller, Request}
@@ -16,7 +17,7 @@ object QueryController extends Controller with JSONParser {
   private val rest: RestHandler = com.kakao.s2graph.rest.Global.s2rest
 
   def delegate(request: Request[JsValue]) =
-    rest.doPost(request.uri, request.body).body.map { js =>
+    rest.doPost(request.uri, request.body, request.headers.get(Experiment.impressionKey)).body.map { js =>
       jsonResponse(js, "result_size" -> rest.calcSize(js).toString)
     } recoverWith ApplicationController.requestFallback(request.body)
 


### PR DESCRIPTION
In experiment sometimes bucket should be fixed.

If "S2-Impression-Id" is provied in request header, 
bucket is fixed and you can get experiment result of provided id' bucket

ex) Query Experiment with specific impression-id

```
"S2-Impression-Id" : ${ impression-id }
```
