### PR TITLE
logging deleteAll request to kafka when label is async

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
@@ -619,7 +619,7 @@ class RequestParser(config: Config) extends JSONParser {
 
   def toDeleteParam(json: JsValue) = {
     val labelName = (json \ "label").as[String]
-    val labels = Label.findByName(labelName).map { l => Seq(l) }.getOrElse(Nil).filterNot(_.isAsync)
+    val labels = Label.findByName(labelName).map { l => Seq(l) }.getOrElse(Nil)
     val direction = (json \ "direction").asOpt[String].getOrElse("out")
 
     val ids = (json \ "ids").asOpt[List[JsValue]].getOrElse(Nil)

--- a/s2rest_play/app/controllers/EdgeController.scala
+++ b/s2rest_play/app/controllers/EdgeController.scala
@@ -195,7 +195,7 @@ object EdgeController extends Controller {
     }
 
     def deleteEach(labels: Seq[Label], direction: String, ids: Seq[JsValue], ts: Long, vertices: Seq[Vertex]) = {
-      enqueueLogMessage(ids, labels, ts, direction, None)
+
       val future = s2.deleteAllAdjacentEdges(vertices.toList, labels, GraphUtil.directions(direction), ts)
       if (withWait) {
         future
@@ -205,7 +205,11 @@ object EdgeController extends Controller {
     }
 
     val deleteFutures = jsValue.as[Seq[JsValue]].map { json =>
-      val (labels, direction, ids, ts, vertices) = requestParser.toDeleteParam(json)
+      val (_labels, direction, ids, ts, vertices) = requestParser.toDeleteParam(json)
+
+      enqueueLogMessage(ids, _labels, ts, direction, None)
+      val labels = _labels.filterNot(_.isAsync)
+
       if (labels.isEmpty || ids.isEmpty) Future.successful(true)
       else deleteEach(labels, direction, ids, ts, vertices)
     }


### PR DESCRIPTION
When label is async, `deleteAll request` can't send to kafka.
